### PR TITLE
Fix compiling issue on windows since version 0.11.0

### DIFF
--- a/src/cmd/view.rs
+++ b/src/cmd/view.rs
@@ -8,7 +8,7 @@ use crate::util::{self, ImmutableRecordHelpers};
 use crate::CliResult;
 use unicode_width::UnicodeWidthStr;
 #[cfg(windows)]
-use CliError;
+use crate::CliError;
 
 const TRAILING_COLS: usize = 8;
 const PER_CELL_PADDING_COLS: usize = 3;


### PR DESCRIPTION
Since version 0.11.0 xan failed to compile on windows due to below error:
```
   Compiling xan v0.14.0 (C:\Users\...\src\xan)
error[E0432]: unresolved import `CliError`
  --> src\cmd\view.rs:11:5
   |
11 | use CliError;
   |     ^^^^^^^^ no external crate `CliError`
   |
help: consider importing this enum instead
   |
11 | use crate::CliError;
   |     ~~~~~~~~~~~~~~~

For more information about this error, try `rustc --explain E0432`.
error: could not compile `xan` (bin "xan") due to 1 previous error
```
A very little change, following the recommendation, fixes the issue.