### PR TITLE
Added xan on Scoop extras bucket (Windows installation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Finally, `xan` can be used to display CSV files in the terminal, for easy explor
 
 * [How to install](#how-to-install)
   * [Cargo](#cargo)
+  * [Scoop (Windows)](#scoop-windows)
   * [Homebrew (macOS)](#homebrew-macos)
   * [Arch Linux](#arch-linux)
   * [Nix](#nix)
@@ -72,6 +73,7 @@ cargo install --git https://github.com/medialab/xan
 `xan` can be installed using [Scoop](https://scoop.sh/) on Windows:
 
 ```powershell
+scoop bucket add extras
 scoop install xan
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ You can also install the latest dev version thusly:
 cargo install --git https://github.com/medialab/xan
 ```
 
+### Scoop (Windows)
+
+`xan` can be installed using [Scoop](https://scoop.sh/) on Windows:
+
+```powershell
+scoop install xan
+```
+
 ### Homebrew (macOS)
 
 `xan` can be installed with [Homebrew](https://brew.sh/) on macOS thusly:


### PR DESCRIPTION
xan can now be installed using Scoop on Windows. It was added on the extras bucket https://github.com/ScoopInstaller/Extras/pull/15175.