### PR TITLE
initial implementation to parse toml entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2178,6 +2178,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "servo_arc"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,6 +2480,40 @@ checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap 2.8.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2787,6 +2830,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2875,6 +2927,7 @@ dependencies = [
  "textwrap",
  "thread_local",
  "threadpool",
+ "toml",
  "topk",
  "transient-btree-index",
  "unicode-segmentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xan"
-version = "0.48.0"  #:version
+version = "0.48.0" #:version
 authors = [
   "Andrew Gallant <jamslam@gmail.com>",
   "Guillaume Plique <guillaume.plique@sciencespo.fr>",
@@ -8,7 +8,7 @@ authors = [
   "Laura Miguel <laura.miguel@sciencespo.fr>",
   "César Pichon <cesar.pichon@sciencespo.fr>",
   "Anna Charles <anna.charles@sciencespo.fr>",
-  "Julien Pontoire <julien.pontoire@sciencespo.fr>"
+  "Julien Pontoire <julien.pontoire@sciencespo.fr>",
 ]
 description = "The CSV magician"
 documentation = "https://github.com/medialab/xan#readme"
@@ -29,7 +29,7 @@ include = [
   "src/moonblade/doc/*.json",
   "src/moonblade/doc/*.md",
   "src/moonblade/doc/*.txt",
-  "tests/**/*.rs"
+  "tests/**/*.rs",
 ]
 
 [[bin]]
@@ -50,7 +50,9 @@ btoi = "0.4.3"
 bytesize = "2.0.1"
 calamine = "0.26.1"
 colored = "2.0.0"
-colorgrad = { version = "0.7.0", default-features = false, features = ["preset"] }
+colorgrad = { version = "0.7.0", default-features = false, features = [
+  "preset",
+] }
 console = "0.15.8"
 crossbeam-channel = "0.2.4"
 csv = "1.3.1"
@@ -106,6 +108,7 @@ textwrap = "0.16.1"
 threadpool = "1.3"
 thread_local = "1.1.8"
 topk = "0.5.0"
+toml = "0.8"
 transient-btree-index = "0.5.1"
 unidecode = "0.3.0"
 unicode-segmentation = "1.12.0"

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,2 @@
+[view]
+flags = ["-p", "-R", "--theme=compact"]

--- a/src/cmd/view.rs
+++ b/src/cmd/view.rs
@@ -322,7 +322,11 @@ impl Args {
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
-    let mut args: Args = util::get_args(USAGE, argv)?;
+    let file_config: util::FileConfig = util::load_config("config.toml")?;
+    let config_args: Vec<String> = file_config.view.flags.clone();
+    let mut merged_args: Vec<&str> = argv.to_vec();
+    merged_args.extend(config_args.iter().map(|s| s.as_str()));
+    let mut args: Args = util::get_args(USAGE, &merged_args)?;
     args.resolve();
 
     let mut env_var_argv = vec!["xan", "view"];

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,10 @@ Please choose one of the following commands/flags:\n{}",
                 eprintln!("{}", msg);
                 process::exit(1);
             }
+            Err(CliError::Toml(msg)) => {
+                eprintln!("{}", msg);
+                process::exit(1);
+            }
             // NOTE: I am not super fan to handle this as an error case...
             Err(CliError::Help(usage)) => {
                 println!("{}", usage);
@@ -378,6 +382,7 @@ pub enum CliError {
     Io(io::Error),
     Other(String),
     Help(String),
+    Toml(toml::de::Error),
 }
 
 impl fmt::Display for CliError {
@@ -388,6 +393,7 @@ impl fmt::Display for CliError {
             CliError::Io(ref e) => e.fmt(f),
             CliError::Other(ref s) => f.write_str(s),
             CliError::Help(ref s) => f.write_str(s),
+            CliError::Toml(ref e) => e.fmt(f),
         }
     }
 }
@@ -535,5 +541,11 @@ impl From<url::ParseError> for CliError {
 impl From<()> for CliError {
     fn from(_: ()) -> CliError {
         CliError::Other("unknown error".to_string())
+    }
+}
+
+impl From<toml::de::Error> for CliError {
+    fn from(err: toml::de::Error) -> CliError {
+        CliError::Toml(err)
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -28,6 +28,7 @@ use unicode_width::UnicodeWidthStr;
 use crate::config::{Config, Delimiter};
 use crate::dates;
 use crate::select::SelectColumns;
+use crate::CliError;
 use crate::CliResult;
 
 pub fn version() -> String {
@@ -858,6 +859,22 @@ pub fn bytes_cursor_from_read<R: io::Read>(source: &mut R) -> io::Result<io::Cur
     let mut bytes = Vec::<u8>::new();
     source.read_to_end(&mut bytes)?;
     Ok(io::Cursor::new(bytes))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ViewConfig {
+    pub flags: Vec<String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct FileConfig {
+    pub view: ViewConfig,
+}
+
+pub fn load_config<P: AsRef<Path>>(filename: P) -> Result<FileConfig, CliError> {
+    let content = fs::read_to_string(filename)?;
+    let config: FileConfig = toml::from_str(&content).map_err(CliError::from)?;
+    Ok(config)
 }
 
 // A custom implementation de/serializing ext-sort chunks as CSV


### PR DESCRIPTION
I would like to propose a new feature, namely introducing a configuration file to set default cli flags: would you be open to consider it? This PR is just a proof of concept that we can improve in case you deem it relevant: if not, feel free to close.

**Problem**: I often find myself running `xan view` with the same set of flags, I would like to have a configuration file (say in `$XDG_CONFIG_HOME`) to define them as default to avoid having to pass them continuously.

**Proposal**: introduce a `config.toml` (for the moment in the project directory, so that you can test), parse the content and merge with the user provided flags.

P. S. This is my first contribution to a rust project, please do not be scared if the code is kindergarten level (it is my first try to an actual codebase :p). Unit tests are missing, I have tried to add one for the unit I have included but I have been unable to do so (my understanding is that the module where I defined the toml parser should be made `pub`, I wanted to wait for your recommendation on this).