### PR TITLE
Add log10 math function for expression

### DIFF
--- a/src/moonblade/functions.rs
+++ b/src/moonblade/functions.rs
@@ -133,6 +133,10 @@ pub fn get_function(name: &str) -> Option<(Function, FunctionArguments)> {
             |args| unary_arithmetic_op(args, DynamicNumber::ln),
             FunctionArguments::unary(),
         ),
+        "log10" => (
+            |args| unary_arithmetic_op(args, DynamicNumber::log10),
+            FunctionArguments::unary(),
+        ),
         "lower" => (lower, FunctionArguments::unary()),
         "lru" => (lru, FunctionArguments::unary()),
         "ltrim" => (ltrim, FunctionArguments::with_range(1..=2)),

--- a/src/moonblade/types/dynamic_number.rs
+++ b/src/moonblade/types/dynamic_number.rs
@@ -117,6 +117,10 @@ impl DynamicNumber {
         self.map_float(f64::ln)
     }
 
+    pub fn log10(self) -> Self {
+        self.map_float(f64::log10)
+    }
+
     pub fn exp(self) -> Self {
         self.map_float(f64::exp)
     }


### PR DESCRIPTION
Hi Xan teams!

This PR adds support for applying base-10 logarithmic transformation (log10) in the xan transform subcommand.

In statistical analyses, it’s common to visualize or normalize p-values by converting them to -log10(p) scale. This PR enables users to easily apply log10 (and optionally abs for -log10(p)) transformations to numeric columns.

Example Usage:
```bash
> echo -e 'p\n0.1\n0.01\n0.001\n0.0000000005' | xan transform p 'log10 | abs'

p
1
2
3
9.301029995663981
```

Let me know if you’d like me to add unit tests or update the documentation.

Best regards,
Wenjie