### PR TITLE
fix: add check for flag hide info in fn merge

### DIFF
--- a/src/cmd/view.rs
+++ b/src/cmd/view.rs
@@ -297,6 +297,10 @@ impl Args {
             from_argv.flag_hide_index = true;
         }
 
+        if !from_argv.flag_hide_info && from_env.flag_hide_info {
+            from_argv.flag_hide_info = true;
+        }
+
         if !from_argv.flag_pager && from_env.flag_pager {
             from_argv.flag_pager = true;
         }


### PR DESCRIPTION
This PR attempts to address https://github.com/medialab/xan/issues/587: it seems no check for `flag_hide_info` exists when merging with the CLI arguments (which results in `-M` always defaulting to false).