### PR TITLE
fix: .bashrc filename in usage example

### DIFF
--- a/src/cmd/completions.rs
+++ b/src/cmd/completions.rs
@@ -22,7 +22,7 @@ For `zsh` you might also need to load Bash compatibility wrt completions thusly:
     $ echo 'autoload -Uz bashcompinit && bashcompinit' >> ~/.zshrc
 
 You will need to reload you shell or source your main shell
-configuration file (`source ~/,bashrc` for bash, for instance) for
+configuration file (`source ~/.bashrc` for bash, for instance) for
 the completions to be activated (this is only required once).
 
 Usage:


### PR DESCRIPTION
This MR replaces `,` with `.` for `bashrc` filename in completions usage example.