### PR TITLE
xan: baseline command

### DIFF
--- a/src/cmd/baseline.rs
+++ b/src/cmd/baseline.rs
@@ -1,0 +1,190 @@
+use regex::bytes::RegexBuilder;
+use std::str::from_utf8;
+
+use crate::config::{Config, Delimiter};
+use crate::select::SelectedColumns;
+use crate::util;
+use crate::CliResult;
+
+static USAGE: &str = "
+Annotate numeric columns with a comparison to a baseline row.
+
+Finds a row matching the given pattern and treats it as the baseline.
+For every other row, numeric cells are formatted as \"value (±N%)\"
+showing the relative difference from the corresponding baseline cell.
+The baseline row itself shows plain values.
+
+Non-numeric cells are passed through unchanged.
+
+Usage:
+    xan baseline [options] <pattern> [<input>]
+    xan baseline --help
+
+baseline options:
+    -s, --select <cols>    Column(s) to search for the baseline pattern.
+                           Defaults to the first column.
+    -c, --compare <cols>   Only compare these columns. By default, all
+                           columns with numeric values in the baseline
+                           row are compared.
+    -i, --ignore-case      Case-insensitive pattern matching.
+
+Common options:
+    -h, --help             Display this message
+    -o, --output <file>    Write output to <file> instead of stdout.
+    -n, --no-headers       When set, the first row will not be interpreted
+                           as headers.
+    -d, --delimiter <arg>  The field delimiter for reading CSV data.
+                           Must be a single character.
+";
+
+#[derive(Deserialize)]
+struct Args {
+    arg_pattern: String,
+    arg_input: Option<String>,
+    flag_select: Option<SelectedColumns>,
+    flag_compare: Option<SelectedColumns>,
+    flag_ignore_case: bool,
+    flag_output: Option<String>,
+    flag_no_headers: bool,
+    flag_delimiter: Option<Delimiter>,
+}
+
+fn try_parse_f64(s: &[u8]) -> Option<f64> {
+    from_utf8(s).ok().and_then(|s| s.trim().parse::<f64>().ok())
+}
+
+fn format_comparison(value: f64, baseline: f64) -> String {
+    if value == baseline {
+        if value == value.round() {
+            return format!("{} (=)", value as i64);
+        }
+        return format!("{} (=)", value);
+    }
+    if baseline == 0.0 {
+        let sign = if value > 0.0 { "+" } else { "-" };
+        if value == value.round() {
+            return format!("{} ({}inf%)", value as i64, sign);
+        }
+        return format!("{} ({}inf%)", value, sign);
+    }
+    let pct = (value - baseline) / baseline * 100.0;
+    let sign = if pct >= 0.0 { "+" } else { "" };
+    if value == value.round() {
+        return format!("{} ({}{:.0}%)", value as i64, sign, pct);
+    }
+    format!("{} ({}{:.0}%)", value, sign, pct)
+}
+
+pub fn run(argv: &[&str]) -> CliResult<()> {
+    let args: Args = util::get_args(USAGE, argv)?;
+
+    let rconfig = Config::new(&args.arg_input)
+        .delimiter(args.flag_delimiter)
+        .no_headers(args.flag_no_headers);
+
+    let mut reader = rconfig.simd_reader()?;
+    let headers = reader.byte_headers()?.clone();
+
+    // determine which columns to search for the pattern
+    let search_sel: Vec<usize> = if let Some(ref sel) = args.flag_select {
+        Config::new(&args.arg_input)
+            .delimiter(args.flag_delimiter)
+            .no_headers(args.flag_no_headers)
+            .select(sel.clone())
+            .selection(&headers)?
+            .to_vec()
+    } else {
+        // default: first column
+        vec![0]
+    };
+
+    // read all records
+    let records: Vec<_> = reader.byte_records().collect::<Result<Vec<_>, _>>()?;
+
+    // find baseline row
+    let pattern = RegexBuilder::new(&args.arg_pattern)
+        .case_insensitive(args.flag_ignore_case)
+        .unicode(false)
+        .build()?;
+
+    let mut baseline_idx: Option<usize> = None;
+    for (i, record) in records.iter().enumerate() {
+        for &col in &search_sel {
+            if col < record.len() && pattern.is_match(&record[col]) {
+                baseline_idx = Some(i);
+                break;
+            }
+        }
+        if baseline_idx.is_some() {
+            break;
+        }
+    }
+
+    let baseline_idx = match baseline_idx {
+        Some(i) => i,
+        None => {
+            return Err(format!(
+                "No row matching pattern '{}' found",
+                args.arg_pattern
+            )
+            .into());
+        }
+    };
+
+    let baseline_record = &records[baseline_idx];
+
+    // determine which columns to compare
+    let compare_cols: Vec<usize> = if let Some(ref sel) = args.flag_compare {
+        Config::new(&args.arg_input)
+            .delimiter(args.flag_delimiter)
+            .no_headers(args.flag_no_headers)
+            .select(sel.clone())
+            .selection(&headers)?
+            .to_vec()
+    } else {
+        // auto-detect: all columns where baseline has a numeric value
+        (0..baseline_record.len())
+            .filter(|&i| try_parse_f64(&baseline_record[i]).is_some())
+            .collect()
+    };
+
+    // parse baseline values for compare columns
+    let mut baseline_vals: Vec<Option<f64>> = vec![None; headers.len()];
+    for &col in &compare_cols {
+        if col < baseline_record.len() {
+            baseline_vals[col] = try_parse_f64(&baseline_record[col]);
+        }
+    }
+
+    // write output
+    let mut wtr = Config::new(&args.flag_output).simd_writer()?;
+
+    if !rconfig.no_headers {
+        wtr.write_byte_record(&headers)?;
+    }
+
+    let mut out_record = simd_csv::ByteRecord::new();
+
+    for (i, record) in records.iter().enumerate() {
+        out_record.clear();
+
+        for col in 0..record.len() {
+            if i == baseline_idx || !compare_cols.contains(&col) {
+                // baseline row or non-compared column: pass through
+                out_record.push_field(&record[col]);
+            } else if let (Some(val), Some(base)) =
+                (try_parse_f64(&record[col]), baseline_vals[col])
+            {
+                let formatted = format_comparison(val, base);
+                out_record.push_field(formatted.as_bytes());
+            } else {
+                // non-numeric: pass through
+                out_record.push_field(&record[col]);
+            }
+        }
+
+        wtr.write_byte_record(&out_record)?;
+    }
+
+    Ok(wtr.flush()?)
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub mod agg;
+pub mod baseline;
 pub mod behead;
 pub mod bins;
 pub mod bisect;

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,7 @@ macro_rules! command_list {
     complete    Add missing rows in a column of contiguous values
     blank       Blank down contiguous identical cell values
     separate    Split a single column into multiple ones
+    baseline    Annotate numeric columns with comparison to a baseline row
 
 ## Format, convert & recombobulate
     behead        Drop header from CSV file
@@ -271,6 +272,7 @@ Please choose one of the following commands/flags:\n{}",
 #[serde(rename_all = "lowercase")]
 enum Command {
     Agg,
+    Baseline,
     Behead,
     Bins,
     Bisect,
@@ -359,6 +361,7 @@ impl Command {
 
         match self {
             Command::Agg => cmd::agg::run(argv),
+            Command::Baseline => cmd::baseline::run(argv),
             Command::Behead | Command::Guillotine => cmd::behead::run(argv),
             Command::Bins => cmd::bins::run(argv),
             Command::Bisect => cmd::bisect::run(argv),

--- a/tests/test_baseline.rs
+++ b/tests/test_baseline.rs
@@ -1,0 +1,251 @@
+use crate::workdir::Workdir;
+
+#[test]
+fn baseline_percentage() {
+    let wrk = Workdir::new("baseline_percentage");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["quant", "pp32", "pp64"],
+            svec!["Q4", "80", "160"],
+            svec!["Q8", "100", "200"],
+            svec!["BF16", "90", "180"],
+        ],
+    );
+    let mut cmd = wrk.command("baseline");
+    cmd.arg("Q8").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["quant", "pp32", "pp64"],
+        svec!["Q4", "80 (-20%)", "160 (-20%)"],
+        svec!["Q8", "100", "200"],
+        svec!["BF16", "90 (-10%)", "180 (-10%)"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn baseline_select_column() {
+    let wrk = Workdir::new("baseline_select_column");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["name", "quant", "val"],
+            svec!["a", "Q4", "80"],
+            svec!["b", "Q8", "100"],
+        ],
+    );
+    let mut cmd = wrk.command("baseline");
+    cmd.arg("Q8").args(["-s", "quant"]).arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["name", "quant", "val"],
+        svec!["a", "Q4", "80 (-20%)"],
+        svec!["b", "Q8", "100"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn baseline_compare_specific_columns() {
+    let wrk = Workdir::new("baseline_compare_cols");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["quant", "pp32", "pp64", "notes"],
+            svec!["Q4", "80", "160", "fast"],
+            svec!["Q8", "100", "200", "slow"],
+        ],
+    );
+    let mut cmd = wrk.command("baseline");
+    cmd.arg("Q8").args(["-c", "pp32"]).arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    // only pp32 should be compared, pp64 stays as-is
+    let expected = vec![
+        svec!["quant", "pp32", "pp64", "notes"],
+        svec!["Q4", "80 (-20%)", "160", "fast"],
+        svec!["Q8", "100", "200", "slow"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn baseline_non_numeric_passthrough() {
+    let wrk = Workdir::new("baseline_non_numeric");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["quant", "val", "label"],
+            svec!["Q4", "80", "fast"],
+            svec!["Q8", "100", "base"],
+        ],
+    );
+    let mut cmd = wrk.command("baseline");
+    cmd.arg("Q8").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["quant", "val", "label"],
+        svec!["Q4", "80 (-20%)", "fast"],
+        svec!["Q8", "100", "base"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn baseline_positive_diff() {
+    let wrk = Workdir::new("baseline_positive");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["quant", "val"],
+            svec!["Q4", "120"],
+            svec!["Q8", "100"],
+        ],
+    );
+    let mut cmd = wrk.command("baseline");
+    cmd.arg("Q8").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["quant", "val"],
+        svec!["Q4", "120 (+20%)"],
+        svec!["Q8", "100"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn baseline_case_insensitive() {
+    let wrk = Workdir::new("baseline_case_insensitive");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["quant", "val"],
+            svec!["Q4", "80"],
+            svec!["q8_0", "100"],
+        ],
+    );
+    let mut cmd = wrk.command("baseline");
+    cmd.arg("Q8_0").arg("-i").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["quant", "val"],
+        svec!["Q4", "80 (-20%)"],
+        svec!["q8_0", "100"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn baseline_equal_values() {
+    let wrk = Workdir::new("baseline_equal");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["quant", "val"],
+            svec!["Q4", "100"],
+            svec!["Q8", "100"],
+        ],
+    );
+    let mut cmd = wrk.command("baseline");
+    cmd.arg("Q8").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["quant", "val"],
+        svec!["Q4", "100 (=)"],
+        svec!["Q8", "100"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn baseline_zero_baseline_positive() {
+    let wrk = Workdir::new("baseline_zero_pos");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["quant", "val"],
+            svec!["Q4", "50"],
+            svec!["Q8", "0"],
+        ],
+    );
+    let mut cmd = wrk.command("baseline");
+    cmd.arg("Q8").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["quant", "val"],
+        svec!["Q4", "50 (+inf%)"],
+        svec!["Q8", "0"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn baseline_zero_baseline_negative() {
+    let wrk = Workdir::new("baseline_zero_neg");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["quant", "val"],
+            svec!["Q4", "-30"],
+            svec!["Q8", "0"],
+        ],
+    );
+    let mut cmd = wrk.command("baseline");
+    cmd.arg("Q8").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["quant", "val"],
+        svec!["Q4", "-30 (-inf%)"],
+        svec!["Q8", "0"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn baseline_zero_both() {
+    let wrk = Workdir::new("baseline_zero_both");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["quant", "val"],
+            svec!["Q4", "0"],
+            svec!["Q8", "0"],
+        ],
+    );
+    let mut cmd = wrk.command("baseline");
+    cmd.arg("Q8").arg("data.csv");
+
+    let got: Vec<Vec<String>> = wrk.read_stdout(&mut cmd);
+    let expected = vec![
+        svec!["quant", "val"],
+        svec!["Q4", "0 (=)"],
+        svec!["Q8", "0"],
+    ];
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn baseline_no_match_error() {
+    let wrk = Workdir::new("baseline_no_match");
+    wrk.create(
+        "data.csv",
+        vec![
+            svec!["quant", "val"],
+            svec!["Q4", "80"],
+            svec!["Q8", "100"],
+        ],
+    );
+    let mut cmd = wrk.command("baseline");
+    cmd.arg("NONEXISTENT").arg("data.csv");
+
+    wrk.assert_err(&mut cmd);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,6 +16,7 @@ macro_rules! svec[
 mod workdir;
 
 mod test_agg;
+mod test_baseline;
 mod test_behead;
 mod test_bisect;
 mod test_cat;


### PR DESCRIPTION
Adding new command baseline, which will allow to use one of the rows as baseline and compare other rows with it.

Example:
```
% xan view /tmp/perf.csv

Displaying 5 cols from 14 rows of /tmp/perf.csv
┌────┬──────────┬──────┬──────┬───────┬───────┐
│ -  │ version  │ sz32 │ sz64 │ sz128 │ sz256 │
├────┼──────────┼──────┼──────┼───────┼───────┤
│ 0  │ Q2_K-gpu │  891 │ 1634 │  2455 │  3355 │
│ 1  │ Q3_K-gpu │  886 │ 1576 │  2295 │  3273 │
│ 2  │ Q4_K-gpu │  884 │ 1633 │  2430 │  3315 │
│ 3  │ Q5_K-gpu │  864 │ 1581 │  2339 │  3173 │
│ 4  │ Q6_K-gpu │  913 │ 1689 │  2486 │  3408 │
│ 5  │ Q8_0-gpu │  996 │ 1853 │  2790 │  3809 │
│ 6  │ BF16-gpu │  845 │ 1534 │  2418 │  3326 │
│ 7  │ Q2_K-cpu │   73 │   94 │   173 │   239 │
│ 8  │ Q3_K-cpu │   81 │  153 │   237 │   296 │
│ 9  │ Q4_K-cpu │  236 │  373 │   457 │   497 │
│ 10 │ Q5_K-cpu │  344 │  423 │   462 │   464 │
│ 11 │ Q6_K-cpu │  354 │  414 │   488 │   524 │
│ 12 │ Q8_0-cpu │  221 │  322 │   502 │   508 │
│ 13 │ BF16-cpu │   54 │   97 │   174 │   236 │
└────┴──────────┴──────┴──────┴───────┴───────┘
```

Here each version represents 'what was running the test' and each of numeric columns represents test size.
Each value is throughput (larger -> better).

Selecting one of the versions as baseline:
```
% xan-dev baseline "Q8_0-gpu" /tmp/perf.csv | xan view

Displaying 5 cols from 14 rows of <stdin>
┌────┬──────────┬────────────┬─────────────┬─────────────┬─────────────┐
│ -  │ version  │ sz32       │ sz64        │ sz128       │ sz256       │
├────┼──────────┼────────────┼─────────────┼─────────────┼─────────────┤
│ 0  │ Q2_K-gpu │ 891 (-11%) │ 1634 (-12%) │ 2455 (-12%) │ 3355 (-12%) │
│ 1  │ Q3_K-gpu │ 886 (-11%) │ 1576 (-15%) │ 2295 (-18%) │ 3273 (-14%) │
│ 2  │ Q4_K-gpu │ 884 (-11%) │ 1633 (-12%) │ 2430 (-13%) │ 3315 (-13%) │
│ 3  │ Q5_K-gpu │ 864 (-13%) │ 1581 (-15%) │ 2339 (-16%) │ 3173 (-17%) │
│ 4  │ Q6_K-gpu │ 913 (-8%)  │ 1689 (-9%)  │ 2486 (-11%) │ 3408 (-11%) │
│ 5  │ Q8_0-gpu │ 996        │ 1853        │ 2790        │ 3809        │
│ 6  │ BF16-gpu │ 845 (-15%) │ 1534 (-17%) │ 2418 (-13%) │ 3326 (-13%) │
│ 7  │ Q2_K-cpu │ 73 (-93%)  │ 94 (-95%)   │ 173 (-94%)  │ 239 (-94%)  │
│ 8  │ Q3_K-cpu │ 81 (-92%)  │ 153 (-92%)  │ 237 (-92%)  │ 296 (-92%)  │
│ 9  │ Q4_K-cpu │ 236 (-76%) │ 373 (-80%)  │ 457 (-84%)  │ 497 (-87%)  │
│ 10 │ Q5_K-cpu │ 344 (-65%) │ 423 (-77%)  │ 462 (-83%)  │ 464 (-88%)  │
│ 11 │ Q6_K-cpu │ 354 (-64%) │ 414 (-78%)  │ 488 (-83%)  │ 524 (-86%)  │
│ 12 │ Q8_0-cpu │ 221 (-78%) │ 322 (-83%)  │ 502 (-82%)  │ 508 (-87%)  │
│ 13 │ BF16-cpu │ 54 (-95%)  │ 97 (-95%)   │ 174 (-94%)  │ 236 (-94%)  │
└────┴──────────┴────────────┴─────────────┴─────────────┴─────────────┘
```

`xan-dev` is symlink to the locally built binary with these changes. `xan` is production version.

Difference is always relative currently.

We can configure which column to search for baseline filter, first column is default.

If baseline value is 0, we might see +inf% and -inf%.

Non-numeric columns are passed without change.

Example with zeroes and more non-numeric columns:

```
% xan view /tmp/calls.csv

Displaying 4 cols from 3 rows of /tmp/calls.csv
┌───┬────────────┬──────────┬───────────┬────────┐
│ - │ date       │ endpoint │ succeeded │ failed │
├───┼────────────┼──────────┼───────────┼────────┤
│ 0 │ 2026-04-08 │ home     │       612 │      0 │
│ 1 │ 2026-04-08 │ contact  │         6 │      0 │
│ 2 │ 2026-04-08 │ chat     │       121 │      2 │
└───┴────────────┴──────────┴───────────┴────────┘

% xan-dev baseline -s endpoint "home" /tmp/calls.csv | xan view

Displaying 4 cols from 3 rows of <stdin>
┌───┬────────────┬──────────┬────────────┬───────────┐
│ - │ date       │ endpoint │ succeeded  │ failed    │
├───┼────────────┼──────────┼────────────┼───────────┤
│ 0 │ 2026-04-08 │ home     │ 612        │ 0         │
│ 1 │ 2026-04-08 │ contact  │ 6 (-99%)   │ 0 (=)     │
│ 2 │ 2026-04-08 │ chat     │ 121 (-80%) │ 2 (+inf%) │
└───┴────────────┴──────────┴────────────┴───────────┘

```
We can see that 0 vs 0 results in '0 (=)' and 0 vs 2 results in '2 (+inf%)'