### PR TITLE
fix(headers): keep trailing space when column index hits 4+ digits

### DIFF
--- a/tests/test_headers.rs
+++ b/tests/test_headers.rs
@@ -42,8 +42,8 @@ h2";
 #[test]
 fn headers_wide_column_index_has_trailing_space() {
     let wrk = Workdir::new("headers_wide_column_index_has_trailing_space");
-    let header: Vec<String> = (0..1001).map(|i| format!("c{}", i)).collect();
-    let row: Vec<String> = (0..1001).map(|i| format!("v{}", i)).collect();
+    let header: Vec<String> = (0..=1000).map(|i| format!("c{}", i)).collect();
+    let row: Vec<String> = (0..=1000).map(|i| format!("v{}", i)).collect();
     wrk.create("in.csv", vec![header, row]);
 
     let mut cmd = wrk.command("headers");

--- a/tests/test_headers.rs
+++ b/tests/test_headers.rs
@@ -40,6 +40,22 @@ h2";
 }
 
 #[test]
+fn headers_wide_column_index_has_trailing_space() {
+    let wrk = Workdir::new("headers_wide_column_index_has_trailing_space");
+    let header: Vec<String> = (0..1001).map(|i| format!("c{}", i)).collect();
+    let row: Vec<String> = (0..1001).map(|i| format!("v{}", i)).collect();
+    wrk.create("in.csv", vec![header, row]);
+
+    let mut cmd = wrk.command("headers");
+    cmd.arg("in.csv");
+
+    let got: String = wrk.stdout(&mut cmd);
+    let last_line = got.lines().last().unwrap();
+    // Index 1000 must be separated from header name by whitespace, not glued.
+    assert_eq!(last_line, "1000 c1000");
+}
+
+#[test]
 fn headers_multiple() {
     let (wrk, mut cmd) = setup("headers_multiple");
     cmd.arg("in2.csv").arg("-j");


### PR DESCRIPTION
Reported in #1056. With 1000+ columns the index ran into the header name (`1000col_1000`) because the left-column width was floored at 4 only when the last index was <=3 digits.

Width is now `(flag_start + last_index).to_string().len() + 1`, with the previous 4-character floor kept for narrow files. Regression test added in `tests/test_headers.rs`.

Closes #1056