### PR TITLE
Fix spark -P to compute percentages over sum, not domain

### DIFF
--- a/src/cmd/spark.rs
+++ b/src/cmd/spark.rs
@@ -324,7 +324,12 @@ impl SparklineRenderer {
         }
     }
 
-    fn show_numbers(&mut self, left_padding: usize, numbers: &[f64], scale_opt: Option<&Scale>) {
+    fn show_numbers(
+        &mut self,
+        left_padding: usize,
+        numbers: &[f64],
+        percentage_denominator: Option<f64>,
+    ) {
         self.draw_buffer.push('\n');
 
         for _ in 0..left_padding {
@@ -336,8 +341,15 @@ impl SparklineRenderer {
         for x in numbers.iter().copied() {
             self.draw_buffer.push_str(
                 &util::unicode_aware_ellipsis(
-                    &(if let Some(scale) = scale_opt {
-                        format!("{:3.0}%", scale.ratio(x) * 100.0)
+                    &(if let Some(denominator) = percentage_denominator {
+                        // Percentages are over the sum of the series, like
+                        // `xan hist`, so the displayed values add up to 100%.
+                        let percentage = if denominator == 0.0 {
+                            0.0
+                        } else {
+                            x / denominator * 100.0
+                        };
+                        format!("{:3.0}%", percentage)
                     } else {
                         util::format_number(x)
                     }),
@@ -1490,7 +1502,11 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                 }
 
                 if args.flag_show_percentages {
-                    sparkline_renderer.show_numbers(name_padding.len(), chunk, Some(&scale));
+                    sparkline_renderer.show_numbers(
+                        name_padding.len(),
+                        chunk,
+                        Some(chunk.iter().sum()),
+                    );
                 }
 
                 if args.flag_show_numbers {

--- a/src/cmd/spark.rs
+++ b/src/cmd/spark.rs
@@ -1466,6 +1466,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
             series.len()
         };
 
+        let series_sum: f64 = series.numbers.iter().sum();
+
         let mut offset: usize = 0;
 
         for (chunk_i, chunk) in series.numbers.chunks(chunk_size).enumerate() {
@@ -1505,7 +1507,7 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
                     sparkline_renderer.show_numbers(
                         name_padding.len(),
                         chunk,
-                        Some(chunk.iter().sum()),
+                        Some(series_sum),
                     );
                 }
 


### PR DESCRIPTION
## Summary
`xan spark -P` now shows each value as a percentage of the series sum, so the displayed percentages add up to 100% - matching how `xan hist` computes its percentages (`bar.value / sum * 100.0` in `src/cmd/hist.rs`). It previously used `Scale::ratio`, which normalizes over the scale domain `(value - min) / width`, so the same series rendered very different numbers in the two commands.

## Why this matters
#1085: "Percentage value should be over sum, not max."

Before/after on a 3-value series `[1, 1, 2]` with `xan spark n -P -W 6`:

```
before:  0%    0%  100%
after:  25%   25%   50%
```

`show_numbers` in `src/cmd/spark.rs` takes the percentage denominator directly (the chunk sum, computed at the `--show-percentages` call site) instead of a `&Scale`, with a zero-sum guard so an all-zero series renders 0% rather than dividing by zero. The sparkline bar heights still scale over the domain - only the displayed percentage changes.

## Testing
- Before/after comparison above, run with the built binary against the stashed and fixed trees
- `cargo check` and `cargo fmt --check` clean on the touched file

Fixes #1085
