### PR TITLE
docs: document strict value+type semantics of moonblade `in`/`not in`

### DIFF
--- a/docs/moonblade/cheatsheet.md
+++ b/docs/moonblade/cheatsheet.md
@@ -53,6 +53,10 @@ fmt("{} {}", first_name, last_name)
 split(mimetype, "/")[0]
 ```
 
+Membership tests using `in` and `not in` use strict equality: both value and
+type must match. Cast string-typed cells explicitly when comparing against typed
+literals, for instance `int(b) not in [1, 2, 3]`.
+
 A common pitfall is to forget that string operators are different than numerical
 ones, like in Perl. String equality is actually `eq`, not `==`, and string
 concatenation would be `++` not `+`. Read the design choices section if you

--- a/docs/moonblade/cheatsheet.md
+++ b/docs/moonblade/cheatsheet.md
@@ -53,9 +53,9 @@ fmt("{} {}", first_name, last_name)
 split(mimetype, "/")[0]
 ```
 
-Membership tests using `in` and `not in` use strict equality: both value and
-type must match. Cast string-typed cells explicitly when comparing against typed
-literals, for instance `int(b) not in [1, 2, 3]`.
+When testing membership against a list, `in` and `not in` use strict equality:
+both value and type must match. Cast string-typed cells explicitly when comparing
+against typed list literals, for instance `int(b) not in [1, 2, 3]`.
 
 A common pitfall is to forget that string operators are different than numerical
 ones, like in Perl. String equality is actually `eq`, not `==`, and string

--- a/docs/moonblade/functions.md
+++ b/docs/moonblade/functions.md
@@ -81,13 +81,15 @@ x ++ y - string concatenation
 
 ### Logical operators
 
+Warning: when the right-hand side is a list, x in y and x not in y use strict equality, matching both value and type. Cast string-typed cells explicitly when comparing against typed list literals, e.g. int(b) not in [1, 2, 3].
+
 ```txt
 x && y     - logical and
 x and y
 x || y     - logical or
 x or y
-x in y
-x not in y
+x in y     - membership test
+x not in y - negated membership test
 ```
 
 ### Indexing & slicing operators

--- a/src/moonblade/doc/cheatsheet.md
+++ b/src/moonblade/doc/cheatsheet.md
@@ -53,6 +53,10 @@ fmt("{} {}", first_name, last_name)
 split(mimetype, "/")[0]
 ```
 
+When testing membership against a list, `in` and `not in` use strict equality:
+both value and type must match. Cast string-typed cells explicitly when comparing
+against typed list literals, for instance `int(b) not in [1, 2, 3]`.
+
 A common pitfall is to forget that string operators are different than numerical
 ones, like in Perl. String equality is actually `eq`, not `==`, and string
 concatenation would be `++` not `+`. Read the design choices section if you

--- a/src/moonblade/doc/operators.json
+++ b/src/moonblade/doc/operators.json
@@ -116,6 +116,7 @@
   },
   {
     "title": "Logical operators",
+    "prelude": "Warning: x in y and x not in y use strict equality, matching both value and type. Cast operands explicitly when testing string-typed cells, e.g. int(b) not in [1, 2, 3].",
     "examples": [
       {
         "snippet": "x && y",
@@ -132,10 +133,12 @@
         "snippet": "x or y"
       },
       {
-        "snippet": "x in y"
+        "snippet": "x in y",
+        "help": "strict membership test"
       },
       {
-        "snippet": "x not in y"
+        "snippet": "x not in y",
+        "help": "negated strict membership test"
       }
     ]
   },

--- a/src/moonblade/doc/operators.json
+++ b/src/moonblade/doc/operators.json
@@ -116,7 +116,7 @@
   },
   {
     "title": "Logical operators",
-    "prelude": "Warning: x in y and x not in y use strict equality, matching both value and type. Cast operands explicitly when testing string-typed cells, e.g. int(b) not in [1, 2, 3].",
+    "prelude": "Warning: when the right-hand side is a list, x in y and x not in y use strict equality, matching both value and type. Cast string-typed cells explicitly when comparing against typed list literals, e.g. int(b) not in [1, 2, 3].",
     "examples": [
       {
         "snippet": "x && y",
@@ -134,11 +134,11 @@
       },
       {
         "snippet": "x in y",
-        "help": "strict membership test"
+        "help": "membership test"
       },
       {
         "snippet": "x not in y",
-        "help": "negated strict membership test"
+        "help": "negated membership test"
       }
     ]
   },


### PR DESCRIPTION
## Summary

The `in` / `not in` operator docs now warn that membership uses strict equality matching both value and type, with the cast workaround (`int(col) in [1, 2, 3]`). The empty `help` strings for `x in y` and `x not in y` are filled in, and the generated Markdown docs are regenerated via `./scripts/docs.sh`.

## Why this matters

#1095: @eeweegh found that `int(b) not in [1, 2, 3]` stopped matching after moonblade switched `contains`/`in` to strict value-and-type equality. @Yomguithereal confirmed the strict semantics are intended and asked for a doc warning ("a warned person makes for two"). The warning is scoped to list membership: string containers still cast the needle and accept regexes, so the prelude describes the list-membership strict-typing behavior the issue is about rather than claiming every `x in y` form is strict.

## Testing

Docs-only change; `./scripts/docs.sh` regenerated `cheatsheet.md` and `functions.md` so the embedded and generated help stay consistent. No Rust behavior change.

Fixes #1095
