### PR TITLE
Add geomean and harmean aggregations

### DIFF
--- a/docs/moonblade/aggs.md
+++ b/docs/moonblade/aggs.md
@@ -44,8 +44,8 @@ the number of nodes in a graph represented by a CSV edge list.
 - **min**(*\<expr\>*) -> `number`: Minimum numerical value.
 - **max**(*\<expr\>*) -> `number`: Maximum numerical value.
 - **mean**(*\<expr\>*) -> `number`: Mean of numerical values. Same as `avg`.
-- **geomean**(*\<expr\>*) -> `number`: Geometric mean of numerical values. Only defined for positive numbers.
-- **harmean**(*\<expr\>*) -> `number`: Harmonic mean of numerical values. Only defined for positive numbers.
+- **geometric_mean**(*\<expr\>*) -> `number`: Geometric mean of numerical values. Only defined for positive numbers.
+- **harmonic_mean**(*\<expr\>*) -> `number`: Harmonic mean of numerical values. Only defined for positive numbers.
 - **median**(*\<expr\>*) -> `number`: Median of numerical values, interpolating on even counts.
 - **median_high**(*\<expr\>*) -> `number`: Median of numerical values, returning higher value on even counts.
 - **median_low**(*\<expr\>*) -> `number`: Median of numerical values, returning lower value on even counts.

--- a/docs/moonblade/aggs.md
+++ b/docs/moonblade/aggs.md
@@ -44,6 +44,8 @@ the number of nodes in a graph represented by a CSV edge list.
 - **min**(*\<expr\>*) -> `number`: Minimum numerical value.
 - **max**(*\<expr\>*) -> `number`: Maximum numerical value.
 - **mean**(*\<expr\>*) -> `number`: Mean of numerical values. Same as `avg`.
+- **geomean**(*\<expr\>*) -> `number`: Geometric mean of numerical values. Only defined for positive numbers.
+- **harmean**(*\<expr\>*) -> `number`: Harmonic mean of numerical values. Only defined for positive numbers.
 - **median**(*\<expr\>*) -> `number`: Median of numerical values, interpolating on even counts.
 - **median_high**(*\<expr\>*) -> `number`: Median of numerical values, returning higher value on even counts.
 - **median_low**(*\<expr\>*) -> `number`: Median of numerical values, returning lower value on even counts.

--- a/src/moonblade/agg/aggregators/mod.rs
+++ b/src/moonblade/agg/aggregators/mod.rs
@@ -24,4 +24,6 @@ pub use sum::Sum;
 pub use temporal::TemporalExtent;
 pub use types::{Type, Types};
 pub use values::Values;
-pub use welford::{CovarianceWelford, RMSWelford, Welford};
+pub use welford::{
+    CovarianceWelford, GeometricMeanWelford, HarmonicMeanWelford, RMSWelford, Welford,
+};

--- a/src/moonblade/agg/aggregators/welford.rs
+++ b/src/moonblade/agg/aggregators/welford.rs
@@ -146,6 +146,62 @@ impl RMSWelford {
     }
 }
 
+// NOTE: geometric mean is computed as the exponential of the mean of the
+// logarithms, which stays numerically stable and lets us reuse Welford's
+// mergeable accumulator. Only defined for strictly positive numbers.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct GeometricMeanWelford(Welford);
+
+impl GeometricMeanWelford {
+    pub fn new() -> Self {
+        Self(Welford::new())
+    }
+
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    pub fn add(&mut self, value: f64) {
+        self.0.add(value.ln());
+    }
+
+    pub fn geometric_mean(&self) -> Option<f64> {
+        self.0.mean().map(|m| m.exp())
+    }
+
+    pub fn merge(&mut self, other: Self) {
+        self.0.merge(other.0);
+    }
+}
+
+// NOTE: harmonic mean is the reciprocal of the mean of the reciprocals, which
+// once again lets us lean on Welford's mergeable accumulator. Only defined for
+// strictly positive numbers.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct HarmonicMeanWelford(Welford);
+
+impl HarmonicMeanWelford {
+    pub fn new() -> Self {
+        Self(Welford::new())
+    }
+
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    pub fn add(&mut self, value: f64) {
+        self.0.add(value.recip());
+    }
+
+    pub fn harmonic_mean(&self) -> Option<f64> {
+        self.0.mean().map(|m| m.recip())
+    }
+
+    pub fn merge(&mut self, other: Self) {
+        self.0.merge(other.0);
+    }
+}
+
 // NOTE: https://stackoverflow.com/questions/45773857/merging-covariance-from-two-sets-to-create-new-covariance
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct CovarianceWelford {
@@ -275,6 +331,72 @@ impl CovarianceWelford {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_close(got: Option<f64>, expected: f64) {
+        let got = got.expect("expected a value");
+        assert!(
+            (got - expected).abs() < 1e-12,
+            "got {}, expected {}",
+            got,
+            expected
+        );
+    }
+
+    #[test]
+    fn test_geometric_mean() {
+        let mut agg = GeometricMeanWelford::new();
+        assert_eq!(agg.geometric_mean(), None);
+
+        // geomean([1, 2, 4]) == cbrt(8) == 2
+        for x in [1.0, 2.0, 4.0] {
+            agg.add(x);
+        }
+        assert_close(agg.geometric_mean(), 2.0);
+
+        // Merging two halves must match the whole
+        let mut left = GeometricMeanWelford::new();
+        let mut right = GeometricMeanWelford::new();
+        let mut whole = GeometricMeanWelford::new();
+
+        for x in [3.0, 9.0] {
+            left.add(x);
+            whole.add(x);
+        }
+        for x in [27.0, 81.0] {
+            right.add(x);
+            whole.add(x);
+        }
+        left.merge(right);
+        assert_close(left.geometric_mean(), whole.geometric_mean().unwrap());
+    }
+
+    #[test]
+    fn test_harmonic_mean() {
+        let mut agg = HarmonicMeanWelford::new();
+        assert_eq!(agg.harmonic_mean(), None);
+
+        // harmean([1, 2, 4]) == 3 / (1 + 0.5 + 0.25) == 12/7
+        for x in [1.0, 2.0, 4.0] {
+            agg.add(x);
+        }
+        assert_close(agg.harmonic_mean(), 12.0 / 7.0);
+
+        // Merging two halves must match the whole
+        let mut left = HarmonicMeanWelford::new();
+        let mut right = HarmonicMeanWelford::new();
+        let mut whole = HarmonicMeanWelford::new();
+
+        for x in [2.0, 5.0] {
+            left.add(x);
+            whole.add(x);
+        }
+        for x in [8.0, 11.0] {
+            right.add(x);
+            whole.add(x);
+        }
+        left.merge(right);
+        assert_close(left.harmonic_mean(), whole.harmonic_mean().unwrap());
+    }
 
     #[test]
     fn test_welford_add_n() {

--- a/src/moonblade/agg/program.rs
+++ b/src/moonblade/agg/program.rs
@@ -844,8 +844,8 @@ fn get_function_arguments_parser(name: &str) -> Option<(FunctionArguments, Argum
         "min" => (FunctionArguments::unary(), |_| Ok(Min)),
         "max" => (FunctionArguments::unary(), |_| Ok(Max)),
         "avg" | "mean" => (FunctionArguments::unary(), |_| Ok(Mean)),
-        "geomean" => (FunctionArguments::unary(), |_| Ok(GeometricMean)),
-        "harmean" => (FunctionArguments::unary(), |_| Ok(HarmonicMean)),
+        "geometric_mean" => (FunctionArguments::unary(), |_| Ok(GeometricMean)),
+        "harmonic_mean" => (FunctionArguments::unary(), |_| Ok(HarmonicMean)),
         "median" => (FunctionArguments::unary(), |_| {
             Ok(Median(MedianType::Interpolation))
         }),

--- a/src/moonblade/agg/program.rs
+++ b/src/moonblade/agg/program.rs
@@ -8,8 +8,8 @@ use simd_csv::ByteRecord;
 
 use super::aggregators::{
     AllAny, ApproxCardinality, ApproxQuantiles, ArgExtent, ArgTop, Count, CovarianceWelford, First,
-    Frequencies, Last, LexicographicExtent, MedianType, Numbers, NumericExtent, RMSWelford, Sum,
-    TemporalExtent, Type, Types, Values, Welford,
+    Frequencies, GeometricMeanWelford, HarmonicMeanWelford, Last, LexicographicExtent, MedianType,
+    Numbers, NumericExtent, RMSWelford, Sum, TemporalExtent, Type, Types, Values, Welford,
 };
 use crate::collections::{ClusteredInsertHashmap, IndexMap, new_index_map};
 use crate::moonblade::error::{ConcretizationError, EvaluationError, SpecifiedEvaluationError};
@@ -33,6 +33,8 @@ enum Aggregator {
     Values(Values),
     LexicographicExtent(LexicographicExtent),
     Frequencies(Box<Frequencies>),
+    GeometricMeanWelford(GeometricMeanWelford),
+    HarmonicMeanWelford(HarmonicMeanWelford),
     Numbers(Numbers),
     RMSWelford(RMSWelford),
     Sum(Sum),
@@ -59,6 +61,8 @@ impl Aggregator {
             Values(inner) => inner.clear(),
             LexicographicExtent(inner) => inner.clear(),
             Frequencies(inner) => inner.clear(),
+            GeometricMeanWelford(inner) => inner.clear(),
+            HarmonicMeanWelford(inner) => inner.clear(),
             Numbers(inner) => inner.clear(),
             RMSWelford(inner) => inner.clear(),
             Sum(inner) => inner.clear(),
@@ -87,6 +91,12 @@ impl Aggregator {
                 inner.merge(other_inner)
             }
             (Frequencies(inner), Frequencies(other_inner)) => inner.merge(*other_inner),
+            (GeometricMeanWelford(inner), GeometricMeanWelford(other_inner)) => {
+                inner.merge(other_inner)
+            }
+            (HarmonicMeanWelford(inner), HarmonicMeanWelford(other_inner)) => {
+                inner.merge(other_inner)
+            }
             (Numbers(inner), Numbers(other_inner)) => inner.merge(other_inner),
             (RMSWelford(inner), RMSWelford(other_inner)) => inner.merge(other_inner),
             (Sum(inner), Sum(other_inner)) => inner.merge(other_inner),
@@ -295,6 +305,12 @@ impl Aggregator {
                 ConcreteAggregationMethod::MostCommonValues(k, separator),
                 Self::Frequencies(inner),
             ) => DynamicValue::from(inner.most_common(*k).join(separator)),
+            (ConcreteAggregationMethod::GeometricMean, Self::GeometricMeanWelford(inner)) => {
+                DynamicValue::from(inner.geometric_mean())
+            }
+            (ConcreteAggregationMethod::HarmonicMean, Self::HarmonicMeanWelford(inner)) => {
+                DynamicValue::from(inner.harmonic_mean())
+            }
             (ConcreteAggregationMethod::Rms, Self::RMSWelford(inner)) => {
                 DynamicValue::from(inner.rms())
             }
@@ -507,6 +523,12 @@ impl CompositeAggregator {
             | ConcreteAggregationMethod::MostCommonValues(_, _) => {
                 upsert_boxed_aggregator!(Frequencies)
             }
+            ConcreteAggregationMethod::GeometricMean => {
+                upsert_aggregator!(GeometricMeanWelford)
+            }
+            ConcreteAggregationMethod::HarmonicMean => {
+                upsert_aggregator!(HarmonicMeanWelford)
+            }
             ConcreteAggregationMethod::Rms => {
                 upsert_aggregator!(RMSWelford)
             }
@@ -601,6 +623,16 @@ impl CompositeAggregator {
                     Aggregator::Numbers(numbers) => {
                         if !value.is_nullish() {
                             numbers.add(value.try_as_number()?);
+                        }
+                    }
+                    Aggregator::GeometricMeanWelford(inner) => {
+                        if !value.is_nullish() {
+                            inner.add(value.try_as_f64()?);
+                        }
+                    }
+                    Aggregator::HarmonicMeanWelford(inner) => {
+                        if !value.is_nullish() {
+                            inner.add(value.try_as_f64()?);
                         }
                     }
                     Aggregator::RMSWelford(inner) => {
@@ -812,6 +844,8 @@ fn get_function_arguments_parser(name: &str) -> Option<(FunctionArguments, Argum
         "min" => (FunctionArguments::unary(), |_| Ok(Min)),
         "max" => (FunctionArguments::unary(), |_| Ok(Max)),
         "avg" | "mean" => (FunctionArguments::unary(), |_| Ok(Mean)),
+        "geomean" => (FunctionArguments::unary(), |_| Ok(GeometricMean)),
+        "harmean" => (FunctionArguments::unary(), |_| Ok(HarmonicMean)),
         "median" => (FunctionArguments::unary(), |_| {
             Ok(Median(MedianType::Interpolation))
         }),
@@ -915,6 +949,8 @@ enum ConcreteAggregationMethod {
     Min,
     Max,
     Mean,
+    GeometricMean,
+    HarmonicMean,
     Median(MedianType),
     Mode,
     Modes(String),

--- a/src/moonblade/doc/aggs.json
+++ b/src/moonblade/doc/aggs.json
@@ -180,13 +180,13 @@
     "help": "Mean of numerical values. Same as `avg`."
   },
   {
-    "name": "geomean",
+    "name": "geometric_mean",
     "arguments": ["<expr>"],
     "returns": "number",
     "help": "Geometric mean of numerical values. Only defined for positive numbers."
   },
   {
-    "name": "harmean",
+    "name": "harmonic_mean",
     "arguments": ["<expr>"],
     "returns": "number",
     "help": "Harmonic mean of numerical values. Only defined for positive numbers."

--- a/src/moonblade/doc/aggs.json
+++ b/src/moonblade/doc/aggs.json
@@ -180,6 +180,18 @@
     "help": "Mean of numerical values. Same as `avg`."
   },
   {
+    "name": "geomean",
+    "arguments": ["<expr>"],
+    "returns": "number",
+    "help": "Geometric mean of numerical values. Only defined for positive numbers."
+  },
+  {
+    "name": "harmean",
+    "arguments": ["<expr>"],
+    "returns": "number",
+    "help": "Harmonic mean of numerical values. Only defined for positive numbers."
+  },
+  {
     "name": "median",
     "arguments": ["<expr>"],
     "returns": "number",

--- a/tests/test_agg.rs
+++ b/tests/test_agg.rs
@@ -25,6 +25,13 @@ fn agg() {
     test_single_agg_function(&wrk, "sum(n) as sum", "sum", "10");
     test_single_agg_function(&wrk, "mean(n) as mean", "mean", "2.5");
     test_single_agg_function(&wrk, "avg(n) as mean", "mean", "2.5");
+    test_single_agg_function(
+        &wrk,
+        "geomean(n) as geomean",
+        "geomean",
+        "2.2133638394006434",
+    );
+    test_single_agg_function(&wrk, "harmean(n) as harmean", "harmean", "1.92");
     test_single_agg_function(&wrk, "min(n) as min", "min", "1");
     test_single_agg_function(&wrk, "max(n) as max", "max", "4");
     test_single_agg_function(&wrk, "median(n) as median", "median", "2.5");

--- a/tests/test_agg.rs
+++ b/tests/test_agg.rs
@@ -27,11 +27,11 @@ fn agg() {
     test_single_agg_function(&wrk, "avg(n) as mean", "mean", "2.5");
     test_single_agg_function(
         &wrk,
-        "geomean(n) as geomean",
-        "geomean",
+        "geometric_mean(n) as geometric_mean",
+        "geometric_mean",
         "2.2133638394006434",
     );
-    test_single_agg_function(&wrk, "harmean(n) as harmean", "harmean", "1.92");
+    test_single_agg_function(&wrk, "harmonic_mean(n) as harmonic_mean", "harmonic_mean", "1.92");
     test_single_agg_function(&wrk, "min(n) as min", "min", "1");
     test_single_agg_function(&wrk, "max(n) as max", "max", "4");
     test_single_agg_function(&wrk, "median(n) as median", "median", "2.5");


### PR DESCRIPTION
Adds `geomean` and `harmean` aggregation functions for the geometric and harmonic means, as requested in #960.

Both are thin wrappers around the existing Welford accumulator (same approach as `rms`), so they stay mergeable for parallel/grouped runs. Geometric mean is computed as the exp of the mean of the logs, harmonic mean as the reciprocal of the mean of the reciprocals. Both are only meaningful for positive numbers, which I noted in the help text.

Closes #960