### PR TITLE
Add fish completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 *Features*
 
 * Support for `.mtx` (Matrix Market) files.
+* Added `xan completions fish`.
 
 *Fixes*
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ autoload -Uz compinit
 compinit
 ```
 
+For `fish`, you can add the completion file to your completions directory, where it will be autoloaded:
+
+```bash
+xan completions fish > ~/.config/fish/completions/xan.fish
+```
+
 ## Quick tour
 
 Let's learn about the most commonly used `xan` commands by exploring a corpus of French medias:

--- a/src/cmd/completions.rs
+++ b/src/cmd/completions.rs
@@ -5,7 +5,7 @@ static USAGE: &str = "
 Print script parts necessary to activate xan completions, tailored
 to your current shell.
 
-Only support `bash` and `zsh` for now.
+Only support `bash`, `zsh` and `fish` for now.
 
 For `bash`, run:
     $ xan completions bash >> ~/.bashrc
@@ -23,12 +23,15 @@ Then add this before compinit in ~/.zshrc:
     autoload -Uz compinit
     compinit
 
+For `fish`, run:
+    $ xan completions fish > ~/.config/fish/completions/xan.fish
+
 You will need to reload your shell or source your main shell
 configuration file (`source ~/.bashrc` for bash, for instance) for
 the completions to be activated (this is only required once).
 
 Usage:
-    xan completions (bash | zsh)
+    xan completions (bash | zsh | fish)
     xan completions --help
 
 Common options:
@@ -65,10 +68,35 @@ else
 fi
 "#;
 
+static FISH_COMPLETE_FUNCTION: &str = r#"# Xan completions
+function __xan_compgen
+    set -l tokens (commandline -opc)
+    set -l current (commandline -ct)
+
+    # The word before the cursor is what selects the completion mode. It is
+    # the right one for the flags taking a column selector, but on
+    # `xan select file.csv <TAB>` it is the file name rather than the
+    # subcommand, so fall back to the subcommand when it matches nothing.
+    set -l previous $tokens[-1]
+
+    if not contains -- $previous -s --select -g --groupby
+        and set -q tokens[2]
+        and test "$previous" != "$tokens[2]"
+        set previous $tokens[2]
+    end
+
+    COMP_LINE="$tokens $current" xan compgen $tokens[1] "$current" "$previous"
+end
+
+# No -f, so that fish still completes file names when xan returns nothing.
+complete -c xan -a '(__xan_compgen)'
+"#;
+
 #[derive(Deserialize)]
 struct Args {
     cmd_bash: bool,
     cmd_zsh: bool,
+    cmd_fish: bool,
 }
 
 pub fn run(argv: &[&str]) -> CliResult<()> {
@@ -78,6 +106,8 @@ pub fn run(argv: &[&str]) -> CliResult<()> {
         println!("{}", BASH_COMPLETE_FUNCTION.trim_end());
     } else if args.cmd_zsh {
         println!("{}", ZSH_COMPLETE_FUNCTION.trim_end());
+    } else if args.cmd_fish {
+        println!("{}", FISH_COMPLETE_FUNCTION.trim_end());
     }
 
     Ok(())


### PR DESCRIPTION
Closes #1152.

Adds a `fish` arm to `xan completions`, alongside `bash` and `zsh`.

Like the two existing scripts, the fish function delegates everything to `xan compgen <cmd> <current> <previous>` and implements no completion logic of its own, so all three shells track `compgen.rs` together.

Two details are fish-specific, both covered in the issue:

- **`<previous>`** is passed verbatim where that works — notably the flags whose value is a column selector (`-s`, `--select`, `-g`, `--groupby`), which `compgen` matches by name. It falls back to the subcommand for `xan select file.csv <TAB>`, where the literal preceding word is the file name and so matches nothing. The fallback is conditional so it doesn't shadow the flags.
- **No `-f`** on the `complete`, so fish keeps completing file names when `compgen` returns nothing — mirroring `-o default` in bash and `_default` in zsh. With `-f`, `xan count <TAB>` offered nothing at all.

Also updates the `completions` usage text, the README install section, and the changelog.

## Testing

`cargo build`, `cargo fmt` and `cargo clippy` are clean, and `./scripts/docs.sh` produces no changes (`completions` has no generated page).

The generated script was installed and driven with `complete -C` against real CSVs, exercising: subcommand listing, prefix filtering (`xan se` → `search`/`select`), columns with and without an explicit file, per-file column resolution across two CSVs, comma-separated selectors (`name,ag` → `name,age`), `-s`/`--select` values, subcommand groups (`xan help`), and file-name fallback.